### PR TITLE
Add support for Magento EE FPC purges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,11 @@ Blocking standard cache-flushed means that there might be old cached data still 
 
 ### Use with Magento EE FPC
 
-In order to use with Magento 1,x EE's FPC, a small configuration change is required.  Without this change, FPC page and container cache entries simply won't be purged.
+Magento 1.x EE's FPC is supported, and purges are queued against it as well.  In some cases, you may wish for user-triggered FPC purges to occur immediately.  It's possible to make queuing apply only to actions from the admin.
 
 In your full_page_cache configuration, add this next to `<backend_options>`:
 
     <frontend_options>
-        <!-- Stores clean operations on the queue as FPC entries. -->
-        <async_cache_type>full_page_cache</async_cache_type>
         <!-- Set to 1 to allow direct frontend purges, such as the cart. -->
         <async_cache_admin_only>1</async_cache_admin_only>
     </frontend_options>
-
-If `async_cache_admin_only` is set to 0 or not present, partially cached pages may not get updated with recent cart changes and similar.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,18 @@ This extension speeds up Magento in situations where the cache gets flushed quit
 ### Important
 
 Blocking standard cache-flushed means that there might be old cached data still used instead of up to date data. Please keep this in mind when developing and running in production and adjust the cronjob for your needs.
+
+### Use with Magento EE FPC
+
+In order to use with Magento 1,x EE's FPC, a small configuration change is required.  Without this change, FPC page and container cache entries simply won't be purged.
+
+In your full_page_cache configuration, add this next to `<backend_options>`:
+
+    <frontend_options>
+        <!-- Stores clean operations on the queue as FPC entries. -->
+        <async_cache_type>full_page_cache</async_cache_type>
+        <!-- Set to 1 to allow direct frontend purges, such as the cart. -->
+        <async_cache_admin_only>1</async_cache_admin_only>
+    </frontend_options>
+
+If `async_cache_admin_only` is set to 0 or not present, partially cached pages may not get updated with recent cart changes and similar.

--- a/app/code/community/Aoe/AsyncCache/Helper/Data.php
+++ b/app/code/community/Aoe/AsyncCache/Helper/Data.php
@@ -32,4 +32,19 @@ class Aoe_AsyncCache_Helper_Data extends Mage_Core_Helper_Abstract
 
         return implode(' // ', $path);
     }
+
+    public function detectCacheType($frontend)
+    {
+        if (Mage::app()->getCache() === $frontend) {
+            return 'config';
+        } else if (Mage::helper('core')->isModuleEnabled('Enterprise_PageCache')) {
+            // Let's check only if full page cache is enabled.
+            $fullPage = Enterprise_PageCache_Model_Cache::getCacheInstance()->getFrontend();
+            if ($fullPage === $frontend) {
+                return 'full_page_cache';
+            }
+        }
+
+        return null;
+    }
 }

--- a/app/code/community/Aoe/AsyncCache/Model/Asynccache.php
+++ b/app/code/community/Aoe/AsyncCache/Model/Asynccache.php
@@ -19,6 +19,8 @@
  * @method Aoe_AsyncCache_Model_Asynccache setStatus(string $status)
  * @method string getProcessed()
  * @method Aoe_AsyncCache_Model_Asynccache setProcessed(string $message)
+ * @method string getCacheType()
+ * @method Aoe_AsyncCacheModel_Asynccache setCacheType(string $type)
  */
 class Aoe_AsyncCache_Model_Asynccache extends Mage_Core_Model_Abstract
 {

--- a/app/code/community/Aoe/AsyncCache/Model/Cleaner.php
+++ b/app/code/community/Aoe/AsyncCache/Model/Cleaner.php
@@ -45,7 +45,8 @@ class Aoe_AsyncCache_Model_Cleaner extends Mage_Core_Model_Abstract
                     $mode = $job->getMode();
                     if (in_array($mode, $this->_supportedJobModes)) {
                         $startTime = time();
-                        Mage::app()->getCache()->clean($job->getMode(), $job->getTags(), true);
+                        $cache = $this->getCacheByType($job->getCacheType());
+                        $cache->clean($job->getMode(), $job->getTags(), true);
                         $job->setDuration(time() - $startTime);
                         $job->setIsProcessed(true);
 
@@ -88,6 +89,20 @@ class Aoe_AsyncCache_Model_Cleaner extends Mage_Core_Model_Abstract
         Mage::register('disableasynccache', true, true);
 
         return $summary;
+    }
+
+    /**
+     * Retrieve the cache frontend for the specified cache type.
+     *
+     * @param string $cacheType Such as 'cache' or 'full_page_cache'.
+     * @return Varien_Cache_Core
+     */
+    protected function getCacheByType($cacheType)
+    {
+        if ($cacheType === 'full_page_cache') {
+            return Enterprise_PageCache_Model_Cache::getCacheInstance()->getFrontend();
+        }
+        return Mage::app()->getCache();
     }
 
     /**

--- a/app/code/community/Aoe/AsyncCache/Model/Job.php
+++ b/app/code/community/Aoe/AsyncCache/Model/Job.php
@@ -9,6 +9,8 @@
  * @method setIsProcessed()
  * @method setAsynccacheId()
  * @method getAsynccacheId()
+ * @method string getCacheType()
+ * @method Aoe_AsyncCache_Model_Job setCacheType(string $type)
  */
 class Aoe_AsyncCache_Model_Job extends Varien_Object
 {
@@ -20,23 +22,28 @@ class Aoe_AsyncCache_Model_Job extends Varien_Object
      */
     public function isEqualTo(Aoe_AsyncCache_Model_Job $job)
     {
-        return ($this->getMode() == $job->getMode()) && ($this->getTags() == $job->getTags());
+        $sameMode = $this->getMode() == $job->getMode();
+        $sameTags = $this->getTags() == $job->getTags();
+        $sameCacheType = $this->getCacheType() == $job->getCacheType();
+        return $sameMode && $sameTags && $sameCacheType;
     }
 
     /**
      * Set mode and tags
      *
      * @param $mode
+     * @param $cacheType
      * @param $tags
      * @return Aoe_AsyncCache_Model_Job
      */
-    public function setParameters($mode, array $tags)
+    public function setParameters($mode, $cacheType, array $tags)
     {
         if ($mode == Zend_Cache::CLEANING_MODE_ALL) {
             $tags = array(); // we don't need any tags for mode 'all'
         }
 
         $this->setData('mode', $mode)
+            ->setData('cache_type', $cacheType)
             ->setData('tags', $tags);
 
         return $this;
@@ -49,7 +56,11 @@ class Aoe_AsyncCache_Model_Job extends Varien_Object
      */
     public function affectsConfigCache()
     {
-        return in_array(Mage_Core_Model_Config::CACHE_TAG, $this->getTags())
-            || $this->getMode() == Zend_Cache::CLEANING_MODE_ALL;
+        $affectsConfig = false;
+        if ($this->getCacheType() == 'cache') {
+            $affectsConfig = $this->getMode() == Zend_Cache::CLEANING_MODE_ALL
+                || in_array(Mage_Core_Model_Config::CACHE_TAG, $this->getTags());
+        }
+        return $affectsConfig;
     }
 }

--- a/app/code/community/Aoe/AsyncCache/Model/JobCollection.php
+++ b/app/code/community/Aoe/AsyncCache/Model/JobCollection.php
@@ -22,6 +22,22 @@ class Aoe_AsyncCache_Model_JobCollection extends Varien_Data_Collection
     }
 
     /**
+     * Remove items from the collection by cacheType.
+     *
+     * @param string $cacheType which type to remove.
+     * @return Aoe_AsyncCache_Model_JobCollection
+     */
+    public function clearByType($cacheType)
+    {
+        foreach ($this->getItems() as $key => $job) {
+            if ($job->getCacheType() == $cacheType) {
+                $this->removeItemByKey($key);
+            }
+        }
+        return $this;
+    }
+
+    /**
      * Summary for Aoe_Scheduler output
      *
      * @return string

--- a/app/code/community/Aoe/AsyncCache/etc/config.xml
+++ b/app/code/community/Aoe/AsyncCache/etc/config.xml
@@ -3,7 +3,7 @@
 
     <modules>
         <Aoe_AsyncCache>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </Aoe_AsyncCache>
     </modules>
 

--- a/app/code/community/Aoe/AsyncCache/sql/aoeasynccache_setup/upgrade-1.0.0-1.1.0.php
+++ b/app/code/community/Aoe/AsyncCache/sql/aoeasynccache_setup/upgrade-1.0.0-1.1.0.php
@@ -1,0 +1,29 @@
+<?php
+/** @var $installer Mage_Core_Model_Resource_Setup */
+$installer = $this;
+
+$installer->startSetup();
+
+$tableName = $installer->getTable('aoeasynccache/asynccache');
+
+$installer->getConnection()->addColumn($tableName, 'cache_type', array(
+    'type' => Varien_Db_Ddl_Table::TYPE_TEXT,
+    'nullable' => false,
+    'length' => 255,
+    'default' => 'cache',
+    'comment' => 'Cache Type',
+));
+
+// Replace the unique index with one accounting for cache type.
+$installer->getConnection()->dropKey(
+    $tableName,
+    $installer->getIdxName('aoeasynccache/asynccache', array('mode', 'tags', 'status'))
+);
+$installer->getConnection()->addIndex(
+    $installer->getTable('aoeasynccache/asynccache'),
+    $installer->getIdxName('aoeasynccache/asynccache', array('cache_type', 'mode', 'tags', 'status')),
+    array('cache_type', 'mode', 'tags', 'status'),
+    Varien_Db_Adapter_Interface::INDEX_TYPE_UNIQUE
+);
+
+$installer->endSetup();

--- a/app/code/community/Varien/Cache/Core.php
+++ b/app/code/community/Varien/Cache/Core.php
@@ -32,6 +32,20 @@ class Varien_Cache_Core extends Zend_Cache_Core
     protected $defaultPriority = 8;
 
     /**
+     * @var string type for asynccache queue.
+     */
+    protected $asyncCacheType = 'cache';
+
+    public function __construct($options = array())
+    {
+        parent::__construct($options);
+
+        if (isset($options['async_cache_type'])) {
+            $this->asyncCacheType = $options['async_cache_type'];
+        }
+    }
+
+    /**
      * Set default priority
      *
      * @param int $defaultPriority
@@ -129,10 +143,12 @@ class Varien_Cache_Core extends Zend_Cache_Core
         if (!$doIt && !Mage::registry('disableasynccache')) {
             /** @var $asyncCache Aoe_AsyncCache_Model_Asynccache */
             $asyncCache = Mage::getModel('aoeasynccache/asynccache');
+
             if ($asyncCache !== false) {
                 $asyncCache->setTstamp(time())
                     ->setMode($mode)
                     ->setTags(is_array($tags) ? implode(',', $tags) : $tags)
+                    ->setCacheType($this->asyncCacheType)
                     ->setStatus(Aoe_AsyncCache_Model_Asynccache::STATUS_PENDING);
 
                 try {

--- a/app/design/adminhtml/default/default/template/aoeasynccache/aoeasynccache.phtml
+++ b/app/design/adminhtml/default/default/template/aoeasynccache/aoeasynccache.phtml
@@ -28,14 +28,16 @@ $_asyncCollection = $this->getAsyncCollection();
         <table class="data" cellspacing="0">
             <thead>
                 <tr class="headings">
-                    <th class=" no-link"><span class="nobr">Mode</span></th>
-                    <th class=" no-link last"><span class="nobr">Tags</span></th>
+                    <th class=" no-link"><span class="nobr"><?php echo Mage::helper('aoeasynccache')->__('Type'); ?></span></th>
+                    <th class=" no-link"><span class="nobr"><?php echo Mage::helper('aoeasynccache')->__('Mode'); ?></span></th>
+                    <th class=" no-link last"><span class="nobr"><?php echo Mage::helper('aoeasynccache')->__('Tags'); ?></span></th>
                 </tr>
             </thead>
             <tbody>
             <?php $i = 0;?>
             <?php foreach ($_asyncCollection->extractJobs() as $job): ?>
                 <tr <?php echo ($i++ % 2) ? '' : 'class="even"'; ?>>
+                    <td><?php echo $job['cache_type']; ?></td>
                     <td><?php echo $job['mode']; ?></td>
                     <td class="a-left last"><?php echo implode('<br />', $job['tags']); ?></td>
                 </tr>
@@ -50,6 +52,7 @@ $_asyncCollection = $this->getAsyncCollection();
             <thead>
                 <tr class="headings">
                     <th class="no-link"><span class="nobr"><?php echo Mage::helper('aoeasynccache')->__('Time') ?></span></th>
+                    <th class="no-link"><span class="nobr"><?php echo Mage::helper('aoeasynccache')->__('Type'); ?></span></th>
                     <th class="no-link"><span class="nobr"><?php echo Mage::helper('aoeasynccache')->__('Mode') ?></span></th>
                     <th class="no-link"><span class="nobr"><?php echo Mage::helper('aoeasynccache')->__('Tags') ?></span></th>
                     <th class="no-link last"><span class="nobr"><?php echo Mage::helper('aoeasynccache')->__('Action') ?></span></th>
@@ -60,6 +63,7 @@ $_asyncCollection = $this->getAsyncCollection();
             <?php foreach ($_asyncCollection as $async): /** @var $async Aoe_AsyncCache_Model_Asynccache */ ?>
                 <tr <?php echo ($i++ % 2) ? '' : 'class="even"'; ?>>
                     <td><?php echo date('H:i:s', Mage::getModel('core/date')->timestamp($async->getTstamp())); ?></td>
+                    <td><?php echo $async->getCacheType(); ?></td>
                     <td><?php echo $async->getMode(); ?></td>
                     <td class="a-left"><?php echo $async->getTags(); ?></td>
                     <td class="a-left last"><a href="<?php echo $this->getUrl('*/async/delete', array('id' => $async->getId())); ?>"><?php echo Mage::helper('aoeasynccache')->__('Delete') ?></a></td>


### PR DESCRIPTION
These changes essentially add a column that tracks which cache the clean was executed against.  Then when executing the queue, this is used to target the correct cache.

The largest changes are around combining queue items for most efficient clearing, since they are now grouped by cache type.

Changes in that area when FPC is not enabled:
- Accumulated tags are now tracked as keys, making unique cheaper.
- When a full purge is hit, all other purges are now dropped (previously some modes would've executed before the full purge.)

Aside from that, if the cache type is unknown (e.g. not the standard Magento cache or full_page_cache, but some other Varien_Cache_Core object), then the queue is bypassed.  Without this, the clean would never hit the correct cache.  Doing that is not perfect in all situations (since it might still regenerate from stale Magento cache), but it's more likely to be correct than ignoring it entirely.
